### PR TITLE
Use biolink CURIE in edge source_id & target_id

### DIFF
--- a/cohd/cohd_translator.py
+++ b/cohd/cohd_translator.py
@@ -898,8 +898,8 @@ class TranslatorResponseMessage:
         kg_edge = {
             'id': ke_id,
             'type': self.query_edge_type,
-            'source_id': omop_concept_curie(node_1['omop_id']),
-            'target_id': omop_concept_curie(node_2['omop_id']),
+            'source_id': node_1['kg_node']['id'],
+            'target_id': node_2['kg_node']['id'],
             'attributes': attributes
         }
 


### PR DESCRIPTION
Fix bug where OMOP IDs were used in edge's source/target_id instead of Biolink CURIE