### PR TITLE
OMOP-Biolink mapping cache updates

### DIFF
--- a/cohd/cohd.py
+++ b/cohd/cohd.py
@@ -211,6 +211,11 @@ def api_internal_build_cache_map_from():
     return api_call('dev', 'build_cache_map_from')
 
 
+@app.route('/api/dev/clear_cache', methods=['GET'])
+def api_internal_clear_cache():
+    return api_call('dev', 'clear_cache')
+
+
 # Retrieves the desired arg_names from args and stores them in the queries dictionary. Returns None if any of arg_names
 # are missing
 def args_to_query(args, arg_names):
@@ -300,11 +305,18 @@ def api_call(service=None, meta=None, query=None, version=None):
         else:
             result = 'meta not recognized', 400
     elif service == 'dev':
-        if meta == 'build_cache_map_from':
-            count = cohd_trapi.BiolinkConceptMapper.build_cache_map_from()
-            result = str(count), 200
+        # Requires a key to run
+        if 'DEV_KEY' in app.config and app.config['DEV_KEY'] == request.args.get('q', None):
+            if meta == 'build_cache_map_from':
+                result = cohd_trapi.BiolinkConceptMapper.build_cache_map_from()
+            elif meta == 'clear_cache':
+                cache.clear()
+                result = 'Cleared cache', 200
+            else:
+                result = 'meta not recognized', 400
         else:
-            result = 'meta not recognized', 400
+            # Pretend like the 'dev' service doesn't exist
+            result = 'service not recognized', 400
     else:
         result = 'service not recognized', 400
 

--- a/cohd/omop_xref.py
+++ b/cohd/omop_xref.py
@@ -4,6 +4,7 @@ from typing import Optional, Union, Dict, List, Tuple, Iterable, Any
 import requests
 from numpy import argsort
 
+from .cohd import cache
 from .cohd_utilities import DomainClass
 
 
@@ -960,6 +961,20 @@ class ConceptMapper:
                 self.domain_targets_omop[domain] = targets_omop
                 self.domain_targets_oxo[domain] = targets_oxo
 
+    def __repr__(self):
+        """ Used in flask cache
+
+        Returns
+        -------
+        String repr
+        """
+        d = {
+            'domain_targets': self.domain_targets,
+            'distance': self.distance,
+            'local_oxo': self.local_oxo
+        }
+        return str(d)
+
     @staticmethod
     def _split_omop_oxo_targets(targets: Iterable[str]) -> Tuple[List, List]:
         """ Given a list of target ontologies, figure out which ones can be retrieved by OMOP mappings. All other target
@@ -990,6 +1005,7 @@ class ConceptMapper:
 
         return targets_omop, targets_oxo
 
+    @cache.memoize(timeout=2419200, cache_none=True)
     def map_to_omop(self, curie):
         """ Map to OMOP concept from ontology
 
@@ -1142,6 +1158,7 @@ class ConceptMapper:
 
         return mappings
 
+    @cache.memoize(timeout=2419200, cache_none=True)
     def map_from_omop_to_target(self,
                                 concept_id: Union[str, int],
                                 target_ontologies: Iterable[str]) -> List[Dict[str, Any]]:

--- a/cohd/scheduled_tasks.py
+++ b/cohd/scheduled_tasks.py
@@ -1,11 +1,13 @@
 import atexit
 from apscheduler.schedulers.background import BackgroundScheduler
 
+from .cohd import cache
 from .cohd_trapi import BiolinkConceptMapper
 
 
 def task_build_cache():
     print('Running scheduled task to build cache')
+    cache.clear()
     BiolinkConceptMapper.build_cache_map_from()
 
 

--- a/cohd/test_unit_tests.py
+++ b/cohd/test_unit_tests.py
@@ -1,13 +1,15 @@
 """
 This test module tests some of the utility functions supporting the COHD API
 """
-from . import cohd_utilities
-from . import omop_xref
 import numpy as np
 import numbers
 import requests
 from time import sleep
 from collections import defaultdict
+
+from . import cohd
+from . import cohd_utilities
+from . import omop_xref
 
 
 def _isnumeric(number_list):


### PR DESCRIPTION
Change the way cache is built for OMOP-Biolink mappings. Separate clearing / recreating cache. Require a key to run dev functions. Cache some omop_xref calls also.