### PR TITLE
Update workflow to be able to trigger manually and add bmt package. U…

### DIFF
--- a/.github/workflows/cohd-monitor.yml
+++ b/.github/workflows/cohd-monitor.yml
@@ -5,6 +5,9 @@ on:
   # Schedule this workflow to run twice a day (at 0300 and 1500 UTC)
   schedule:
     - cron: '0 3/12 * * *'
+  
+  # Also allow manually triggering this workflow_dispatch:
+  workflow_dispatch:
 
 jobs:
   build:
@@ -20,7 +23,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pytest requests pandas matplotlib reasoner-validator==0.9.2.*
+        pip install pytest requests pandas matplotlib bmt
     - name: Test cohd.io
       # Test cohd.io by running pytest on test_cohd_io.py
       # pytest -s disables pytest from capturing print statements (i.e., print statements will appear in console)

--- a/test_cohd_trapi.py
+++ b/test_cohd_trapi.py
@@ -7,10 +7,13 @@ Intended to be run with pytest: pytest -s test_cohd_trapi.py
 from collections import namedtuple
 import requests
 import json as j
+from bmt import Toolkit
 
 from notebooks.cohd_helpers import cohd_requests as cr
 from cohd.trapi import reasoner_validator_11x, reasoner_validator_10x
-from cohd.cohd_trapi import bm_toolkit
+
+# Static instance of the Biolink Model Toolkit
+bm_toolkit = Toolkit()
 
 """ 
 tuple for storing pairs of (key, type) for results schemas


### PR DESCRIPTION
…pdate test_cohd_trapi.py to import bmt directly rather than import from cohd_trapi module