### PR TITLE
nginx: don't log health status checks, even on errors, because of log…

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -74,6 +74,7 @@ http {
 
         location /health {
             access_log off;  # Don't log health status checks
+            error_log /dev/null;  # Also don't log errors on health status checks because of flooding
             include uwsgi_params;
             uwsgi_pass unix:///tmp/uwsgi.sock;
             uwsgi_read_timeout 60;


### PR DESCRIPTION
… flooding